### PR TITLE
Update binary path

### DIFF
--- a/Casks/neovim-nightly.rb
+++ b/Casks/neovim-nightly.rb
@@ -6,5 +6,5 @@ cask 'neovim-nightly' do
   name 'Neovim Nightly'
   homepage 'https://neovim.io/'
 
-  binary 'nvim-osx64/bin/nvim'
+  binary 'nvim-macos/bin/nvim'
 end


### PR DESCRIPTION
Latest neovim nightlies are using `nvim-macos` as a path, which breaks this cask.

```sh
> curl -sL https://github.com/neovim/neovim/releases/download/nightly/nvim-macos.tar.gz | tar --list | grep '/bin/nvim'
nvim-macos/bin/nvim
```