### PR TITLE
Use github release page's sha256sum file

### DIFF
--- a/Casks/neovim-nightly.rb
+++ b/Casks/neovim-nightly.rb
@@ -1,8 +1,17 @@
-cask 'neovim-nightly' do
-  version :latest
-  sha256 :no_check
+require 'open-uri'
 
-  url "https://github.com/neovim/neovim/releases/download/nightly/nvim-macos.tar.gz"
+BASE_URL = 'https://github.com/neovim/neovim/releases/download/nightly/'.freeze
+SHA256_FILENAME = 'nvim-macos.tar.gz.sha256sum'.freeze
+
+cask 'neovim-nightly' do
+  url = "#{BASE_URL}#{SHA256_FILENAME}"
+  checksum, filename = URI.parse(url).open.read.chomp.split(' ')
+  https_filename = "#{BASE_URL}#{filename}"
+
+  version :latest
+  sha256 checksum
+
+  url https_filename
   name 'Neovim Nightly'
   homepage 'https://neovim.io/'
 


### PR DESCRIPTION
This avoids unnecessary downloads in case artifact hadn't changed since last download.
Additionally, this would add a weak guard against corrupted artifacts.